### PR TITLE
Add template-react-spa-site to default template list

### DIFF
--- a/src/InitStack.Cmd/GlobalSettings.cs
+++ b/src/InitStack.Cmd/GlobalSettings.cs
@@ -28,7 +28,8 @@ public class GlobalSettings(IConfiguration configuration) : BaseSettings(configu
     new[]
     {
       "https://github.com/rolfwessels/template-dotnet-core-graphql-app.git",
-      "https://github.com/rolfwessels/template-dotnet-core-console-app.git"
+      "https://github.com/rolfwessels/template-dotnet-core-console-app.git",
+      "https://github.com/rolfwessels/template-react-spa-site.git"
     });
 
   public string[] CommitMessages => ReadConfigValue("CommitMessages",


### PR DESCRIPTION
Adds https://github.com/rolfwessels/template-react-spa-site.git to the default GitSources list so it shows up in the init-stack template selector.